### PR TITLE
Add option for required checkbox with legal messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "nypr-widget-base": "^1.0.2",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
-    "react-scripts": "1.0.17"
+    "react-scripts": "1.0.17",
+    "sanitize-html": "^1.19.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/RequiredCheckbox.css
+++ b/src/RequiredCheckbox.css
@@ -1,0 +1,84 @@
+.RequiredCheckbox {
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.RequiredCheckbox__label {
+  display: flex;
+}
+
+.RequiredCheckbox__checkbox {
+  margin: 3px 6px 0 0;
+}
+
+.RequiredCheckbox__text {
+  font-size: 12px;
+  color: rgba(0,0,0,0.55);
+  flex-grow: 1;
+}
+
+.RequiredCheckbox__error {
+  font-size: 14px;
+  margin: 14px 0 0 0;
+}
+
+.RequiredCheckbox__checkbox {
+  /*screenreader only*/
+  border: 0;
+  clip: rect(0,0,0,0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+/* custom checkbox */
+.RequiredCheckbox__custom-checkbox {
+  position: relative;
+  display: block;
+  cursor: pointer;
+  min-width: 18px;
+  height: 18px;
+  margin: 0 8px 0 2px;
+  border: 2px solid rgba(0,0,0,0.55);
+}
+
+/* focus state */
+.RequiredCheckbox__checkbox:focus ~ .RequiredCheckbox__custom-checkbox {
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: Highlight;
+}
+@media (-webkit-min-device-pixel-ratio:0) { /* only in webkit */
+  .RequiredCheckbox__checkbox:focus ~ .RequiredCheckbox__custom-checkbox {
+    /* mimic webkit native focus styles */
+    outline-width: 5px;
+    outline-color: -webkit-focus-ring-color;
+    outline-style: auto;
+  }
+}
+
+/* error state */
+.RequiredCheckbox__custom-checkbox.error {
+  border-color: #ff0000;
+}
+
+/* custom checkmark */
+.RequiredCheckbox__checkbox:checked ~ .RequiredCheckbox__custom-checkbox:after {
+  content: "";
+  position: absolute;
+  top: 3.5px;
+  left: 2.5px;
+  width: 9px;
+  height: 5px;
+  /* rotate these borders: |__ to make a checkmark shape */
+  border: solid #000000;
+  border-width: 0 0 2px 2px;
+  transform: rotate(-45deg);
+}
+
+@media only screen and (min-width: 481px) {
+
+}

--- a/src/RequiredCheckbox.css
+++ b/src/RequiredCheckbox.css
@@ -7,10 +7,6 @@
   display: flex;
 }
 
-.RequiredCheckbox__checkbox {
-  margin: 3px 6px 0 0;
-}
-
 .RequiredCheckbox__text {
   font-size: 12px;
   color: rgba(0,0,0,0.55);
@@ -80,5 +76,7 @@
 }
 
 @media only screen and (min-width: 481px) {
-
+  .RequiredCheckbox__custom-checkbox {
+    margin-left: 6px;
+  }
 }

--- a/src/RequiredCheckbox.js
+++ b/src/RequiredCheckbox.js
@@ -2,16 +2,12 @@ import React, { Component } from "react"
 import './RequiredCheckbox.css';
 
 class RequiredCheckbox extends Component {
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-    this.state = {
-      changed: false,
-      checked: this.props.checked || false,
-    }
+  state = {
+    changed: false,
+    checked: this.props.checked || false
   }
 
-  handleChange(e) {
+  handleChange = e => {
     this.setState({changed: true, checked: e.target.checked});
     this.props.onChange(e.target.checked)
   }
@@ -29,7 +25,7 @@ class RequiredCheckbox extends Component {
             checked={checked}
             className="RequiredCheckbox__checkbox"
             onChange={this.handleChange} />
-            <span className={"RequiredCheckbox__custom-checkbox " + (hasError ? 'error' : '')}></span>
+            <span className={`RequiredCheckbox__custom-checkbox ${hasError && 'error'}`}></span>
           <div className="RequiredCheckbox__text" dangerouslySetInnerHTML={{__html:message}} />
         </label>
         {hasError && 

--- a/src/RequiredCheckbox.js
+++ b/src/RequiredCheckbox.js
@@ -1,0 +1,43 @@
+import React, { Component } from "react"
+import './RequiredCheckbox.css';
+
+class RequiredCheckbox extends Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {
+      changed: false,
+      checked: this.props.checked || false,
+    }
+  }
+
+  handleChange(e) {
+    this.setState({changed: true, checked: e.target.checked});
+    this.props.onChange(e.target.checked)
+  }
+
+  render() {
+    const { message, submitTried } = this.props;
+    const { changed, checked } = this.state;
+    const hasError = (changed || submitTried) && !checked;
+    const error = this.props.error || "This field is required."
+    return(
+      <div className="RequiredCheckbox">
+        <label className="RequiredCheckbox__label">
+          <input 
+            type="checkbox"
+            checked={checked}
+            className="RequiredCheckbox__checkbox"
+            onChange={this.handleChange} />
+            <span className={"RequiredCheckbox__custom-checkbox " + (hasError ? 'error' : '')}></span>
+          <div className="RequiredCheckbox__text" dangerouslySetInnerHTML={{__html:message}} />
+        </label>
+        {hasError && 
+          <div className="RequiredCheckbox__error">{error}</div>
+        }
+      </div>
+    );
+  }
+}
+
+export default RequiredCheckbox

--- a/src/RequiredCheckbox.test.js
+++ b/src/RequiredCheckbox.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RequiredCheckbox from './RequiredCheckbox';
+import { mount } from 'enzyme';
+
+it('renders without crashing', () => {
+  const REQUIRED_PROPS = {
+  };
+  const div = document.createElement('div');
+  ReactDOM.render(<RequiredCheckbox {...REQUIRED_PROPS} />, div);
+});
+
+it('calls the onChange event', done => {
+  const PROPS = {
+    onChange: jest.fn()
+  }
+  const component = mount(<RequiredCheckbox {...PROPS} />);
+
+  component
+    .find('.RequiredCheckbox__checkbox')
+    .simulate('change',{ target: { checked: false } });
+
+  expect(PROPS.onChange).toHaveBeenCalledTimes(1);
+  expect(PROPS.onChange).lastCalledWith(false);
+
+  component
+    .find('.RequiredCheckbox__checkbox')
+    .simulate('change',{ target: { checked: true } });
+
+  expect(PROPS.onChange).toHaveBeenCalledTimes(2);
+  expect(PROPS.onChange).lastCalledWith(true);
+  done();
+})
+
+it('renders the message', done => {
+  const PROPS = {
+    message: 'test message foo bar baz'
+  }
+  const component = mount(<RequiredCheckbox {...PROPS} />);
+  expect(component.find('.RequiredCheckbox__text').text().trim()).toMatch('test message foo bar baz');
+  done();
+});

--- a/src/SignupForm.css
+++ b/src/SignupForm.css
@@ -16,7 +16,7 @@
   line-height: 1.75;
   font-family: 'Open Sans', sans-serif;
   padding: 2px 5px;
-  border: none;
+  border: 1px solid #f1f1f1;
   margin-bottom: 12px;
 }
 
@@ -25,6 +25,7 @@
 }
 
 .SignupForm > button {
+  width: 100%;
   appearance: none;
   cursor: pointer;
   display: block;
@@ -33,22 +34,26 @@
   background-color: #dcf42c;
   font-family: "Oswald", sans-serif;
   font-size: 18px;
+  margin-bottom: 14px;
+}
+
+.SignupForm > button.disabled {
+  opacity: 0.6;
 }
 
 .SignupForm__message {
-  position: absolute;
   width: 100%;
-  top: 70px;
   font-size: 14px;
 }
 
 @media only screen and (min-width: 481px) {
+
   .SignupForm__message {
-    top: 40px;
+    margin: 0 0 16px 0;
   }
 
   .SignupForm input {
-    margin-bottom: 0;
+    margin-bottom: 16px;
     font-size: 18px;
     padding: 5px 10px;
   }
@@ -58,6 +63,8 @@
   }
 
   .SignupForm button {
+    width: auto;
+    margin-bottom: 16px;
     font-size: 22px;
     padding-left: 15px;
     padding-right: 15px;

--- a/src/SignupForm.css
+++ b/src/SignupForm.css
@@ -12,10 +12,10 @@
 
 .SignupForm > input {
   flex: 1 1 100%;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.75;
   font-family: 'Open Sans', sans-serif;
-  padding: 2px 5px;
+  padding: 6px 5px;
   border: 1px solid #f1f1f1;
   margin-bottom: 12px;
 }
@@ -65,7 +65,7 @@
   .SignupForm button {
     width: auto;
     margin-bottom: 16px;
-    font-size: 22px;
+    font-size: 20px;
     padding-left: 15px;
     padding-right: 15px;
     flex-grow: 0;

--- a/src/SignupForm.js
+++ b/src/SignupForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react"
+import RequiredCheckbox from './RequiredCheckbox';
 import jsonp from "jsonp"
 import './SignupForm.css';
 
@@ -10,6 +11,7 @@ function formatLinks(msg) {
     var links = dom.querySelectorAll("a");
     links.forEach(function(link) {
       link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener');
     });
     let div = document.createElement("div");
     div.appendChild(dom);
@@ -21,15 +23,19 @@ function formatLinks(msg) {
 
 class SubscribeForm extends Component {
   constructor(props) {
-    super(props)
+    super(props);
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
     this.state = {
+      checkboxChecked: true,
+      submitTried: false,
       status: null,
       msg: null
-    }
+    };
   }
   onSubmit = e => {
     e.preventDefault()
 
+    this.setState({submitTried: true});
     if (!this.input.value) {
       this.setState({
         status: 'error',
@@ -42,11 +48,17 @@ class SubscribeForm extends Component {
         msg: 'Must be a valid email address.'
       });
       return;
+    } else if (this.state.optIn && !this.state.checkboxChecked) {
+      return;
     }
 
     const url = getAjaxUrl(this.props.action) + `&EMAIL=${encodeURIComponent(this.input.value)}`;
 
     this.setState({ status: "sending", msg: null }, this.submit.bind(this, url));
+  }
+
+  handleCheckboxChange(checked) {
+    this.setState({checkboxChecked: checked});
   }
 
   submit(url) {
@@ -73,8 +85,8 @@ class SubscribeForm extends Component {
   }
 
   render() {
-    const { action, messages } = this.props
-    const { status, msg } = this.state
+    const { action, messages, optIn, legalMessage } = this.props;
+    const { status, msg, checkboxChecked, submitTried } = this.state;
     return (
       <form className={`SignupForm${status ? ' SignupForm--extend' : ''}`} action={action} method="post" noValidate>
         <input
@@ -87,14 +99,24 @@ class SubscribeForm extends Component {
         />
         <button
           style={this.props.buttonStyle}
-          className="gtm__newsletter"
+          className={"gtm__newsletter " + (optIn && !checkboxChecked ? ' disabled' : '')}
           disabled={this.state.status === "sending"}
           onClick={this.onSubmit}
           type="submit"
         >
-          {messages.btnLabel}
+        {messages.btnLabel}
         </button>
-        <p className="SignupForm__message" dangerouslySetInnerHTML={ {__html: messages[status] || msg } } />
+        { msg &&
+          <p className="SignupForm__message" dangerouslySetInnerHTML={ {__html: messages[status] || msg } } />
+        }
+        {optIn && 
+          <RequiredCheckbox 
+            message={legalMessage} 
+            onChange={this.handleCheckboxChange} 
+            submitTried={submitTried} 
+            checked={true} 
+            error="You must agree to the terms." />
+        }
       </form>
     );
   }

--- a/src/SignupForm.js
+++ b/src/SignupForm.js
@@ -22,16 +22,13 @@ function formatLinks(msg) {
 }
 
 class SubscribeForm extends Component {
-  constructor(props) {
-    super(props);
-    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
-    this.state = {
-      checkboxChecked: true,
-      submitTried: false,
-      status: null,
-      msg: null
-    };
+  state = {
+    checkboxChecked: true,
+    submitTried: false,
+    status: null,
+    msg: null
   }
+
   onSubmit = e => {
     e.preventDefault()
 
@@ -57,7 +54,7 @@ class SubscribeForm extends Component {
     this.setState({ status: "sending", msg: null }, this.submit.bind(this, url));
   }
 
-  handleCheckboxChange(checked) {
+  handleCheckboxChange = checked => {
     this.setState({checkboxChecked: checked});
   }
 
@@ -87,6 +84,7 @@ class SubscribeForm extends Component {
   render() {
     const { action, messages, optIn, legalMessage } = this.props;
     const { status, msg, checkboxChecked, submitTried } = this.state;
+    const isDisabled = optIn && !checkboxChecked;
     return (
       <form className={`SignupForm${status ? ' SignupForm--extend' : ''}`} action={action} method="post" noValidate>
         <input
@@ -99,7 +97,7 @@ class SubscribeForm extends Component {
         />
         <button
           style={this.props.buttonStyle}
-          className={"gtm__newsletter " + (optIn && !checkboxChecked ? ' disabled' : '')}
+          className={`gtm__newsletter ${isDisabled && 'disabled'}`}
           disabled={this.state.status === "sending"}
           onClick={this.onSubmit}
           type="submit"

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,6 +127,13 @@ ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -214,7 +221,7 @@ array-union@^1.0.1:
   dependencies:
     array-uniq "^1.0.1"
 
-array-uniq@^1.0.1:
+array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
@@ -1286,6 +1293,15 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.0"
@@ -2950,6 +2966,11 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -3081,6 +3102,18 @@ html-webpack-plugin@2.29.0:
     lodash "^4.17.3"
     pretty-error "^2.0.2"
     toposort "^1.0.0"
+
+htmlparser2@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
+  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.0.6"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -4017,6 +4050,11 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -4025,13 +4063,33 @@ lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.mergewith@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
 
 lodash.template@^4.4.0:
   version "4.4.0"
@@ -5076,6 +5134,15 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
+postcss@^6.0.14:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5435,6 +5502,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
+  integrity sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -5745,6 +5821,22 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
+sanitize-html@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.19.1.tgz#e8b33c69578054d6ee4f57ea152d6497f3f6fb7d"
+  integrity sha512-zNYr6FvBn4bZukr9x2uny6od/9YdjCLwF+FqxivqI0YOt/m9GIxfX+tWhm52tBAPUXiTTb4bJTGVagRz5b06bw==
+  dependencies:
+    chalk "^2.3.0"
+    htmlparser2 "^3.9.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.0"
+    postcss "^6.0.14"
+    srcset "^1.0.0"
+    xtend "^4.0.0"
+
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -5987,6 +6079,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  integrity sha1-pWad4StC87HV6D7QPHEEb8SPQe8=
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
+
 sshpk@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
@@ -6057,6 +6157,13 @@ string_decoder@^1.0.0, string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -6123,6 +6230,13 @@ supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
 
 svgo@^0.7.0:
   version "0.7.2"
@@ -6443,7 +6557,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
https://jira.wnyc.org/browse/GT-1229

This pairs with https://github.com/nypublicradio/nypr-toolkit/pull/19
- Adds `optIn`,`legalText` parameters to control the appearance of  an optional required checkbox with messaging.
- All HTML in legalText is stripped, all http/https urls are turned into links with the url itself as the link text, and a few hardcoded keywords (e.g.`{WNYC_TERMS}`) are transformed into links with predefined link text.
- A few style tweaks to start bringing things closer to the designs currently in zeplin.