### PR TITLE
GT-1229 Fix Defaults

### DIFF
--- a/src/NewsletterSignup.js
+++ b/src/NewsletterSignup.js
@@ -14,29 +14,19 @@ const FORM_PROPS = {
   }
 };
 
+const LEGAL_TEXT_FOR_PARTNER = {
+  'None': `By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="_blank" rel="noopener">Terms of Use</a>.`,
+  'ProPublica': `By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="_blank" rel="noopener">Terms of Use</a> and in accordance with the <a href="https://www.propublica.org/legal/" target="_blank" rel="noopener">Privacy Policy</a> of ProPublica.`,
+}
+
 const linkify = function(text) {
   // sanitize html coming from the embed string
   let cleanText = sanitizeHtml(text, {allowedTags: [], allowedAttributes: []});
-  // inject a tags for our links
-  let officialLinks = [
-    {
-     tag:   '{WNYC_TERMS}',
-     title: 'Terms of Use',
-     url:   'https://www.wnyc.org/terms/'
-    }, {
-     tag:   '{PROPUBLICA_PRIVACY}',
-     title: 'Privacy Policy',
-     url:   'https://www.propublica.org/legal/'
-    }
-  ];
   let urlMatcher = new RegExp("(\\s?)((http|https)://[^\\s<]+[^\\s<.)])", "gim");
   let results = cleanText.replace(urlMatcher, (match, whitespace, url) => {
     return `${whitespace}<a href="${encodeURI(url)}" target="_blank" rel="noopener">${url}</a>`;
   });
-  officialLinks.forEach(({tag, title, url}) => {
-    results = results.replace(tag, `<a href="${url}" target="_blank" rel="noopener">${title}</a>`)
-  })
-  return results
+  return results;
 }
 
 export default class NewsletterSignup extends WidgetBase {
@@ -49,12 +39,16 @@ export default class NewsletterSignup extends WidgetBase {
   }
 
   render() {
-    let defaultLegalText = "By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our {WNYC_TERMS}.";
-    let { mailchimpId, headline, optIn, legalText} = this.state;
-    let usingCustomText = optIn;
-    legalText = !legalText && !usingCustomText ? defaultLegalText : legalText;
-    console.log('lt', typeof legalText);
-    let legalMessage = linkify(legalText);
+    let { mailchimpId, headline, partnerOrg='None', legalText=''} = this.state;
+
+    let legalMessage;
+    if (partnerOrg === 'Other') {
+      legalMessage = linkify(legalText);
+    } else if(LEGAL_TEXT_FOR_PARTNER[partnerOrg]) {
+      legalMessage = LEGAL_TEXT_FOR_PARTNER[partnerOrg];
+    } else {
+      legalMessage = LEGAL_TEXT_FOR_PARTNER['None'];
+    }
 
     if (!mailchimpId && !headline) {
       return (

--- a/src/NewsletterSignup.js
+++ b/src/NewsletterSignup.js
@@ -44,7 +44,7 @@ export default class NewsletterSignup extends WidgetBase {
     let legalMessage;
     if (partnerOrg === 'Other') {
       legalMessage = linkify(legalText);
-    } else if(LEGAL_TEXT_FOR_PARTNER[partnerOrg]) {
+    } else if (LEGAL_TEXT_FOR_PARTNER[partnerOrg]) {
       legalMessage = LEGAL_TEXT_FOR_PARTNER[partnerOrg];
     } else {
       legalMessage = LEGAL_TEXT_FOR_PARTNER['None'];

--- a/src/NewsletterSignup.js
+++ b/src/NewsletterSignup.js
@@ -49,7 +49,11 @@ export default class NewsletterSignup extends WidgetBase {
   }
 
   render() {
+    let defaultLegalText = "By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our {WNYC_TERMS}.";
     let { mailchimpId, headline, optIn, legalText} = this.state;
+    let usingCustomText = optIn;
+    legalText = !legalText && !usingCustomText ? defaultLegalText : legalText;
+    console.log('lt', typeof legalText);
     let legalMessage = linkify(legalText);
 
     if (!mailchimpId && !headline) {
@@ -65,7 +69,7 @@ export default class NewsletterSignup extends WidgetBase {
         <div className="NewsletterSignup__wrapper">
           <span className="NewsletterSignup__accent" style={this.style('accent')}></span>
           <h1 className="NewsletterSignup__headline" style={this.style('h1')}>{this.state.headline || 'Stay up-to-date'}</h1>
-          <SignupForm {...FORM_PROPS} buttonStyle={this.style('button')} optIn={optIn} legalMessage={legalMessage} />
+          <SignupForm {...FORM_PROPS} buttonStyle={this.style('button')} legalMessage={legalMessage} />
         </div>
       </div>
     );

--- a/src/SignupForm.js
+++ b/src/SignupForm.js
@@ -82,9 +82,9 @@ class SubscribeForm extends Component {
   }
 
   render() {
-    const { action, messages, optIn, legalMessage } = this.props;
+    const { action, messages, legalMessage } = this.props;
     const { status, msg, checkboxChecked, submitTried } = this.state;
-    const isDisabled = optIn && !checkboxChecked;
+    const isDisabled = !checkboxChecked;
     return (
       <form className={`SignupForm${status ? ' SignupForm--extend' : ''}`} action={action} method="post" noValidate>
         <input
@@ -107,14 +107,12 @@ class SubscribeForm extends Component {
         { msg &&
           <p className="SignupForm__message" dangerouslySetInnerHTML={ {__html: messages[status] || msg } } />
         }
-        {optIn && 
-          <RequiredCheckbox 
-            message={legalMessage} 
-            onChange={this.handleCheckboxChange} 
-            submitTried={submitTried} 
-            checked={true} 
-            error="You must agree to the terms." />
-        }
+        <RequiredCheckbox
+          message={legalMessage}
+          onChange={this.handleCheckboxChange}
+          submitTried={submitTried}
+          checked={true}
+          error="You must agree to the terms." />
       </form>
     );
   }

--- a/src/SignupForm.js
+++ b/src/SignupForm.js
@@ -45,7 +45,7 @@ class SubscribeForm extends Component {
         msg: 'Must be a valid email address.'
       });
       return;
-    } else if (this.state.optIn && !this.state.checkboxChecked) {
+    } else if (!this.state.checkboxChecked) {
       return;
     }
 

--- a/src/SignupForm.test.js
+++ b/src/SignupForm.test.js
@@ -26,6 +26,6 @@ it('it passes the url to the submit method', done => {
     done();
   });
   
-  form.find('input').instance().value = EMAIL;
+  form.find('input[type="email"]').instance().value = EMAIL;
   form.find('button').simulate('click');
 })


### PR DESCRIPTION
Set default legal text depending on `partnerOrg`.

If the `partnerOrg` is Other, use `legalText`.
If the `partnerOrg` is in the `LEGAL_TEXT_FOR_PARTNER` list use that text.
Otherwise, use the `None` partnerOrg default text.

Since we're not passing default messages into the widget via iframe query parameters anymore, this also removes the weird `officialLinks` stuff because we can just add the html in the message now.